### PR TITLE
Duplicate craft for 5MG => 5x1MG

### DIFF
--- a/crafting.lua
+++ b/crafting.lua
@@ -113,12 +113,6 @@ minetest.register_craft({
 
 minetest.register_craft({
 	type = "shapeless",
-	output = "currency:minegeld 5",
-	recipe = {"currency:minegeld_5"},
-})
-
-minetest.register_craft({
-	type = "shapeless",
 	output = "currency:minegeld_10 5",
 	recipe = {"currency:minegeld_50"},
 })


### PR DESCRIPTION
Fixes https://github.com/BlockySurvival/issue-tracker/issues/335

Craft is duplicated, remove second copy